### PR TITLE
Redo syntax, give nice parse errors, add defaults, add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,57 @@
 Development status: unreleased
 
 No commitment is made to backward compatibility and little effort is directed toward current user experience or maintaining high transient reliability.
+
+# Usage
+
+## What this does
+
+TODO
+
+## Who can use this tool
+
+Everyone with a github account who is interested in open source software! You do not
+need any permissions to invoke a bisection. You may execute arbitrary bisection code
+on any public repository, whether or not you have any permissions in that repository.
+See [Security](#security) for how we make this possible.
+
+## Invocation syntax
+
+An invocation is a github comment with a trigger and a code block. For example,
+
+````
+Let's try to bisect this.
+
+@LilithHafnerBot bisect(new=main, old=v1.0.0)
+
+```julia
+using Statistics
+mean([1, 2, 3]) == 2
+```
+````
+
+The trigger must take the form `@LilithHafnerBot bisect(<args>)` where `<args>` is
+a (possibly empty) comma separated list of arguments. Each argument must be of the form
+`<key>=<value>`. Supported keys are
+
+- `new`: the new end of the bisection
+- `old`: the old end of the bisection
+
+Any value that can be interpreted as a revision by `git checkout <value>` can be used
+as the value for `new` and `old`. For example, commit hashes, branch names, and tags
+are all valid values.
+
+Line breaks and `)` characters are not permitted in the argument list.
+
+The code block must be a Julia code block, beginning with
+```` ```julia ```` and ending with ```` ``` ````. The trigger and code block must be in
+the same comment.
+
+## Security
+
+TODO (the documentation, that is. The security is already in place.)
+
+### DOS attacks
+
+This service runs on free github action runners. It's trivial to DOS this service,
+please don't do that intentionally.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,24 @@ The code block must be a Julia code block, beginning with
 ```` ```julia ```` and ending with ```` ``` ````. The trigger and code block must be in
 the same comment.
 
+### Default values for `old` and `new`
+
+The default value for `new` is "HEAD", which for issues, points to the head of hhe default
+branch and for pull requests, points to the head of the pull request branch (even if that
+pull request is from a fork!)
+
+The default value for `old` is more complicated. We attempts to find the oldest release on
+the current breaking version (e.g. "v1.0.0"). The exact details are subject to change, but the current
+implementation is
+
+- Filter down to tags that can be parsed by `VersionString`
+- If possible, filter out any tags that have a prerelease or build component
+- If there's any tag with a nonzero major version, keep only tags with the highest major version
+  and otherwise keep only tags with the highest minor version
+- Of the remaining tags, take the earliest according to symbolic version comparison breaking
+  ties lexicographically (e.g. if your repo has both a 1.0.0 tag and a v1.0.0 tag, this will
+  prefer 1.0.0)
+
 ## Security
 
 TODO (the documentation, that is. The security is already in place.)

--- a/src/Bisect.jl
+++ b/src/Bisect.jl
@@ -313,7 +313,7 @@ function populate_default_args!(args::Dict)
     println("Old succeeds: $old_succeeds")
     after = readchomp(`git rev-parse HEAD`)
     println("After 1: $after")
-    before == after || run(`git switch -`, io...)
+    before == after || run(`git switch - --detach`, io...)
 
     before2 = readchomp(`git rev-parse HEAD`)
     println("Before 2: $before2")
@@ -321,7 +321,7 @@ function populate_default_args!(args::Dict)
     println("New succeeds: $new_succeeds")
     after = readchomp(`git rev-parse HEAD`)
     println("After 2: $after")
-    before == after || run(`git switch -`, io...)
+    before == after || run(`git switch - --detach`, io...)
 
     run(ignorestatus(`git stash pop`), io...)
 

--- a/src/Bisect.jl
+++ b/src/Bisect.jl
@@ -300,29 +300,15 @@ function populate_default_args!(args::Dict)
     get!(default_old, args, "old")
     get!(default_new, args, "new")
 
-    # TODO make this more robustly stateless
-    io = ()#devnull, devnull, devnull
+    # TODO make this more robust.
+    io = devnull, devnull, devnull
     old = args["old"]
     new = args["new"]
-
-    run(ignorestatus(`git stash`), io...)
-
-    before = readchomp(`git rev-parse HEAD`)
-    println("Before 1: $before")
+    initial_ref = readchomp(`sh -c 'git symbolic-ref --short HEAD || git rev-parse HEAD'`)
     old_succeeds = success(`git checkout $old`)
-    println("Old succeeds: $old_succeeds")
-    after = readchomp(`git rev-parse HEAD`)
-    println("After 1: $after")
-    before == after || run(`git switch - --detach`, io...)
-
-    before2 = readchomp(`git rev-parse HEAD`)
-    println("Before 2: $before2")
+    run(`git checkout $initial_ref`, io...)
     new_succeeds = success(`git checkout $new`)
-    println("New succeeds: $new_succeeds")
-    after = readchomp(`git rev-parse HEAD`)
-    println("After 2: $after")
-    before == after || run(`git switch - --detach`, io...)
-
+    run(`git checkout $initial_ref`, io...)
     run(ignorestatus(`git stash pop`), io...)
 
     if !old_succeeds || !new_succeeds

--- a/src/Bisect.jl
+++ b/src/Bisect.jl
@@ -334,13 +334,6 @@ function populate_default_args!(args::Dict)
     end
 end
 
-using JSON3, HTTP
-function get_comment(link)
-    m = match(r"https://github.com/([\w\.\+\-]+)/([\w\.\+\-]+)/(pull|issues)/(\d+)#issue(comment)?-(\d+)", link)
-    response = JSON3.read(`gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/$(m[1])/$(m[2])/issues/comments/$(m[6])`)
-    response["body"]
-end
-
 function _workflow(link, comment, path; verbose=true)
     verbose && println(link)
     verbose && println(repr(comment))
@@ -368,6 +361,13 @@ function _workflow(link, comment, path; verbose=true)
     verbose && display(md(res; display_limit=10_000))
 
     md(res; display_limit=DEFAULT_DISPLAY_LIMIT)
+end
+
+using JSON3, HTTP
+function get_comment(link) # TODO: this is unused
+    m = match(r"https://github.com/([\w\.\+\-]+)/([\w\.\+\-]+)/(pull|issues)/(\d+)#issue(comment)?-(\d+)", link)
+    response = JSON3.read(`gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/$(m[1])/$(m[2])/issues/comments/$(m[6])`)
+    response["body"]
 end
 
 function workflow(link=ENV["BISECT_TRIGGER_LINK"])

--- a/src/Bisect.jl
+++ b/src/Bisect.jl
@@ -301,7 +301,7 @@ function populate_default_args!(args::Dict)
     get!(default_new, args, "new")
 
     # TODO make this more robustly stateless
-    io = devnull, devnull, devnull
+    io = ()#devnull, devnull, devnull
     old = args["old"]
     new = args["new"]
 
@@ -310,6 +310,7 @@ function populate_default_args!(args::Dict)
     before = readchomp(`git rev-parse HEAD`)
     println("Before 1: $before")
     old_succeeds = success(`git checkout $old`)
+    println("Old succeeds: $old_succeeds")
     after = readchomp(`git rev-parse HEAD`)
     println("After 1: $after")
     before == after || run(`git switch -`, io...)
@@ -317,6 +318,7 @@ function populate_default_args!(args::Dict)
     before2 = readchomp(`git rev-parse HEAD`)
     println("Before 2: $before2")
     new_succeeds = success(`git checkout $new`)
+    println("New succeeds: $new_succeeds")
     after = readchomp(`git rev-parse HEAD`)
     println("After 2: $after")
     before == after || run(`git switch -`, io...)

--- a/src/Bisect.jl
+++ b/src/Bisect.jl
@@ -225,7 +225,7 @@ function parse_args(args)
     allowed_keys = ("new", "old")
     allowed_keys_str = "\"" * join(allowed_keys, "\", \"", "\", and \"") * "\""
     err = Any[]
-    for arg in eachsplit(args, ',')
+    for arg in split(args, ',')
         kv = split(arg, '=')
         st_arg = strip(arg)
         if length(kv) > 2

--- a/src/Bisect.jl
+++ b/src/Bisect.jl
@@ -259,7 +259,7 @@ function maybe_checkcout_pr!(link)
     m = match(r"https://github.com/([\w\.\+\-]+)/([\w\.\+\-]+)/(pull|issues)/(\d+)#issue(comment)?-(\d+)", link)
     m === nothing && return
     m[3] == "pull" || return
-    run(`hr pr checkout $(m[4])`)
+    run(`gh pr checkout $(m[4])`)
 end
 
 default_new() = "HEAD"

--- a/src/Bisect.jl
+++ b/src/Bisect.jl
@@ -308,12 +308,17 @@ function populate_default_args!(args::Dict)
     run(ignorestatus(`git stash`), io...)
 
     before = readchomp(`git rev-parse HEAD`)
+    println("Before 1: $before")
     old_succeeds = success(`git checkout $old`)
     after = readchomp(`git rev-parse HEAD`)
+    println("After 1: $after")
     before == after || run(`git switch -`, io...)
 
+    before2 = readchomp(`git rev-parse HEAD`)
+    println("Before 2: $before2")
     new_succeeds = success(`git checkout $new`)
     after = readchomp(`git rev-parse HEAD`)
+    println("After 2: $after")
     before == after || run(`git switch -`, io...)
 
     run(ignorestatus(`git stash pop`), io...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -145,7 +145,7 @@ using Markdown
         @test occursin("Bisect succeeded", string(workflow))
 
         # Strange newline characters
-        comment = "`@LilithHafnerBot bisect(old=06051c5cf084fefc43b06bf2527960db6489a6ec)`\r \r `new=main`\r `old = 06051c5cf084fefc43b06bf2527960db6489a6ec`\r \r ```julia\r @assert 1+1 == 2\r ```\n"
+        comment = "`@LilithHafnerBot bisect(new=main, old=06051c5cf084fefc43b06bf2527960db6489a6ec)`\r \r `new=main`\r `old = 06051c5cf084fefc43b06bf2527960db6489a6ec`\r \r ```julia\r @assert 1+1 == 2\r ```\n"
         workflow2 = Bisect._workflow("no link", comment, @__DIR__, verbose=false)
         standard2 = bisect(@__DIR__, """@assert 1+1 == 2""", old="06051c5cf084fefc43b06bf2527960db6489a6ec", new="main")
         @test workflow2 == standard2


### PR DESCRIPTION
Add a bunch of loc to redo comment syntax, give nice parse errors, add clever (too clever?) defaults, and add documentation

Helps with #15 
Fixes #16 
Fixes #17